### PR TITLE
Add usage of port mapping for Boot2docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Node.js Hello World on CentOS using [docker][].
         # curl localhost:49163
 
     It should print `Hello World` to the console.
+    
+    If you use Boot2Docker on OS X, the port is actually mapped to the Docker host VM, and you should use the following command:
+    
+        curl $(boot2docker ip):<port>
 
 ## Acknowledgements
 


### PR DESCRIPTION
I see this tutorial is written for Ubuntu VM on Vagrant, but it also applied to OS X. I hope adding this extraneous piece can make it more friendlier for Mac users of Docker.
